### PR TITLE
🔒 Security: Remove shell: true from spawn to prevent command injection

### DIFF
--- a/helpers/install.ts
+++ b/helpers/install.ts
@@ -69,8 +69,7 @@ function runCommand(command: string, args: string[], cwd: string): Promise<void>
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       cwd,
-      stdio: 'pipe', 
-      shell: true
+      stdio: 'pipe'
     });
 
     let stderr = '';


### PR DESCRIPTION
## 개요

spawn 함수에서 `shell: true` 옵션을 제거하여 커맨드 인젝션 공격으로부터 보호합니다.

## 변경사항

- `helpers/install.ts`에서 spawn 함수의 `shell: true` 옵션 제거
- args 배열이 이미 사용 중이므로 shell 없이도 안전하게 작동

## 관련 이슈

Closes #38 (item 1)