### PR TITLE
🐛 Fix: Add error message when directory is not empty

### DIFF
--- a/helpers/create.ts
+++ b/helpers/create.ts
@@ -33,6 +33,7 @@ export async function createProject(dir: string, options: ProjectOptions = {}) {
 
   // 디렉토리가 비어있는지 확인
   if (existsSync(resolvedPath) && !isFolderEmpty(resolvedPath, projectName)) {
+    console.log(red("✖") + " Directory is not empty. Please use an empty directory.");
     process.exit(1);
   }
 


### PR DESCRIPTION
## 개요

디렉토리가 비어있지 않을 때 사용자가 이해할 수 있는 에러 메시지를 출력합니다.

## 변경사항

- `helpers/create.ts`에 에러 메시지 추가
- 붉은색 아이콘과 함께 친절한 메시지 출력
- 사용자 경험 개선

## 관련 이슈

Closes #38 (item 2)