### PR TITLE
♻️ Refactor: Remove 'as any' type assertion from Axios interceptor

### DIFF
--- a/templates/default-axios/ts/src/libs/axios/customAxios.ts
+++ b/templates/default-axios/ts/src/libs/axios/customAxios.ts
@@ -13,7 +13,10 @@ const axiosRequestConfig: AxiosRequestConfig = {
 
 const customAxios = axios.create(axiosRequestConfig);
 
-customAxios.interceptors.request.use(requestInterceptor as any, (err) => Promise.reject(err));
+customAxios.interceptors.request.use(
+  (config) => requestInterceptor(config, '/login'),
+  (err) => Promise.reject(err)
+);
 
 customAxios.interceptors.response.use((res) => res, ResponseHandler);
 

--- a/templates/vite-axios/ts/src/libs/axios/customAxios.ts
+++ b/templates/vite-axios/ts/src/libs/axios/customAxios.ts
@@ -13,7 +13,10 @@ const axiosRequestConfig: AxiosRequestConfig = {
 
 const customAxios = axios.create(axiosRequestConfig);
 
-customAxios.interceptors.request.use(requestInterceptor as any, (err) => Promise.reject(err));
+customAxios.interceptors.request.use(
+  (config) => requestInterceptor(config, '/login'),
+  (err) => Promise.reject(err)
+);
 
 customAxios.interceptors.response.use((res) => res, ResponseHandler);
 


### PR DESCRIPTION
## 개요

Axios 인터셉터에서 `as any` 타입 어설션을 제거하여 TypeScript 타입 안정성을 개선합니다.

## 변경사항

- `templates/default-axios/ts/src/libs/axios/customAxios.ts` 수정
- `templates/vite-axios/ts/src/libs/axios/customAxios.ts` 수정
- `as any` 제거 및 함수 래퍼로 대체
- 타입 안정성 보장

## 관련 이슈

Closes #38 (item 3)