### PR TITLE
fix :: 템플릿 및 CLI 버그 수정

### DIFF
--- a/helpers/create.ts
+++ b/helpers/create.ts
@@ -44,8 +44,23 @@ export async function createProject(dir: string, options: ProjectOptions = {}) {
   }
   console.log();
 
-  const answers = await prompts([
-    {
+  const validBundlers = ["default", "webpack", "vite"];
+  const validLanguages = ["ts", "js"];
+  const validPkgManagers = ["npm", "yarn", "pnpm", "bun"];
+
+  const validate = (label: string, value: string | undefined, allowed: string[]) => {
+    if (value && !allowed.includes(value)) {
+      console.log(red("✖") + ` Invalid --${label} "${value}". Allowed: ${allowed.join(", ")}`);
+      process.exit(1);
+    }
+  };
+  validate("bundler", options.bundler, validBundlers);
+  validate("language", options.language, validLanguages);
+  validate("package-manager", options.packageManager, validPkgManagers);
+
+  const questions: prompts.PromptObject[] = [];
+  if (!options.bundler) {
+    questions.push({
       type: "select",
       name: "bundler",
       message: "Choose a bundler:",
@@ -54,52 +69,65 @@ export async function createProject(dir: string, options: ProjectOptions = {}) {
         { title: "Webpack", value: "webpack" },
         { title: "Vite", value: "vite" },
       ],
-    },
-    {
-      type: "select", 
+    });
+  }
+  if (!options.language) {
+    questions.push({
+      type: "select",
       name: "language",
       message: "Choose a language:",
       choices: [
         { title: "TypeScript", value: "ts" },
         { title: "JavaScript", value: "js" },
       ],
-    },
-    {
+    });
+  }
+  if (!options.packageManager) {
+    questions.push({
       type: "select",
-      name: "packageManager", 
+      name: "packageManager",
       message: "Choose a package manager:",
-      choices: ["npm", "yarn", "pnpm", "bun"].map(p => ({ title: p, value: p })),
-    },
-    {
+      choices: validPkgManagers.map(p => ({ title: p, value: p })),
+    });
+  }
+  if (typeof options.axios !== "boolean") {
+    questions.push({
       type: "confirm",
       name: "useAxios",
       message: "Include Axios?",
       initial: true,
-    },
-  ], {
-    onCancel: () => {
-      console.log();
-      console.log(red("✖") + " Operation cancelled");
-      process.exit(0);
-    }
-  });
+    });
+  }
 
-  // 사용자가 중간에 취소한 경우
-  if (!answers.bundler) {
+  const answers = questions.length > 0
+    ? await prompts(questions, {
+        onCancel: () => {
+          console.log();
+          console.log(red("✖") + " Operation cancelled");
+          process.exit(0);
+        },
+      })
+    : ({} as Record<string, unknown>);
+
+  const bundler = (options.bundler ?? (answers.bundler as string | undefined));
+  const language = (options.language ?? (answers.language as string | undefined));
+  const useAxios = typeof options.axios === "boolean" ? options.axios : (answers.useAxios as boolean | undefined);
+
+  if (!bundler || !language || typeof useAxios !== "boolean") {
     console.log();
     console.log(red("✖") + " Operation cancelled");
     process.exit(0);
   }
 
-  const packageManager = answers.packageManager || getPkgManager();
+  const packageManager = (options.packageManager ?? (answers.packageManager as string | undefined) ?? getPkgManager());
 
   await installTemplate({
     appName: projectName,
     root: resolvedPath,
-    bundler: answers.bundler,
-    language: answers.language,
-    useAxios: answers.useAxios,
+    bundler: bundler as "default" | "vite" | "webpack",
+    language: language as "ts" | "js",
+    useAxios,
     packageManager,
-    skipInstall: false,
+    skipInstall: options.skipInstall ?? false,
   });
 }

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,8 @@
 import { Command } from "commander";
 import { createProject } from "./helpers/create";
 import { green, cyan } from "picocolors";
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const pkg = require("./package.json");
 
 interface ProgramOptions {
   bundler?: string;
@@ -15,12 +17,13 @@ const program = new Command();
 program
   .name("b1nd-react-app")
   .description("Create a new project with B1ND Boilerplate")
-  .version("1.0.0")
+  .version(pkg.version)
   .argument("[directory]", "Project directory (use '.' for current directory)")
-  .option("--bundler <bundler>", "Choose bundler: default, vite, webpack", "default")
-  .option("--language <language>", "Choose language: ts, js", "ts")
+  .option("--bundler <bundler>", "Choose bundler: default, vite, webpack")
+  .option("--language <language>", "Choose language: ts, js")
   .option("--package-manager <pm>", "Choose package manager: npm, yarn, pnpm, bun")
-  .option("--axios", "Include Axios", false)
+  .option("--axios", "Include Axios")
+  .option("--no-axios", "Exclude Axios")
   .option("--skip-install", "Skip dependency installation", false)
   .action(async (directory: string | undefined, options: ProgramOptions) => {
     

--- a/templates/default-axios/js/src/libs/axios/requestInterceptor.js
+++ b/templates/default-axios/js/src/libs/axios/requestInterceptor.js
@@ -2,14 +2,17 @@
 import token from "../token/token";
 import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY, REQUEST_TOKEN_KEY } from "../../constants/token.constants";
 
-const requestInterceptor = (config , url) => {
+// CHANGE THIS to your login URL
+const LOGIN_URL = "/login";
+
+const requestInterceptor = (config) => {
   if (typeof window !== "undefined") {
     const accessToken = token.getToken(ACCESS_TOKEN_KEY);
     const refreshToken = token.getToken(REFRESH_TOKEN_KEY);
 
     if (!accessToken || !refreshToken) {
       console.error("Access token or refresh token not found.");
-      window.location.href = url;
+      window.location.href = LOGIN_URL;
     } else {
       config.headers[REQUEST_TOKEN_KEY] = `Bearer ${accessToken}`;
     }

--- a/templates/default-axios/js/src/libs/axios/responseInterceptor.js
+++ b/templates/default-axios/js/src/libs/axios/responseInterceptor.js
@@ -30,7 +30,7 @@ const ResponseHandler = async (error) => {
 
       try {
         const { data: newAccessToken } = await axios.post(`${CONFIG.server}/refresh`, {
-          refreshToken: usingAccessToken,
+          refreshToken: usingRefreshToken,
         }); //CHANGE YOUR API URL && BODY VALUE
         customAxios.defaults.headers.common[REQUEST_TOKEN_KEY] = `Bearer ${newAccessToken}`;
 

--- a/templates/default-axios/js/src/libs/token/token.js
+++ b/templates/default-axios/js/src/libs/token/token.js
@@ -11,12 +11,18 @@ class Token {
   }
 
   setToken(key, value) {
-    document.cookie = `${key}=${value}`;
+    document.cookie = `${key}=${encodeURIComponent(value)}; path=/`;
     return document.cookie;
   }
 
   clearToken() {
-    document.cookie = "max-age=0";
+    const cookies = document.cookie.split("; ");
+    for (const cookie of cookies) {
+      const [cookieKey] = cookie.split("=");
+      if (cookieKey) {
+        document.cookie = `${cookieKey}=; path=/; max-age=0`;
+      }
+    }
   }
 }
 

--- a/templates/default-axios/ts/src/libs/axios/customAxios.ts
+++ b/templates/default-axios/ts/src/libs/axios/customAxios.ts
@@ -13,7 +13,7 @@ const axiosRequestConfig: AxiosRequestConfig = {
 
 const customAxios = axios.create(axiosRequestConfig);
 
-customAxios.interceptors.request.use(requestInterceptor as any, (err) => Promise.reject(err));
+customAxios.interceptors.request.use(requestInterceptor, (err) => Promise.reject(err));
 
 customAxios.interceptors.response.use((res) => res, ResponseHandler);
 

--- a/templates/default-axios/ts/src/libs/axios/requestInterceptor.ts
+++ b/templates/default-axios/ts/src/libs/axios/requestInterceptor.ts
@@ -2,14 +2,17 @@ import { InternalAxiosRequestConfig } from "axios";
 import token from "../token/token";
 import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY, REQUEST_TOKEN_KEY } from "../../constants/token.constants";
 
-const requestInterceptor = (config: InternalAxiosRequestConfig, url: string): InternalAxiosRequestConfig => {
+// CHANGE THIS to your login URL
+const LOGIN_URL = "/login";
+
+const requestInterceptor = (config: InternalAxiosRequestConfig): InternalAxiosRequestConfig => {
   if (typeof window !== "undefined") {
     const accessToken = token.getToken(ACCESS_TOKEN_KEY);
     const refreshToken = token.getToken(REFRESH_TOKEN_KEY);
 
     if (!accessToken || !refreshToken) {
       console.error("Access token or refresh token not found.");
-      window.location.href = url;
+      window.location.href = LOGIN_URL;
     } else {
       config.headers[REQUEST_TOKEN_KEY] = `Bearer ${accessToken}`;
     }

--- a/templates/default-axios/ts/src/libs/axios/responseInterceptor.ts
+++ b/templates/default-axios/ts/src/libs/axios/responseInterceptor.ts
@@ -30,7 +30,7 @@ const ResponseHandler = async (error: AxiosError) => {
 
       try {
         const { data: newAccessToken } = await axios.post(`${CONFIG.server}/refresh`, {
-          refreshToken: usingAccessToken,
+          refreshToken: usingRefreshToken,
         }); //CHANGE YOUR API URL && BODY VALUE
         customAxios.defaults.headers.common[REQUEST_TOKEN_KEY] = `Bearer ${newAccessToken}`;
 

--- a/templates/default-axios/ts/src/libs/token/token.ts
+++ b/templates/default-axios/ts/src/libs/token/token.ts
@@ -14,12 +14,18 @@ class Token {
   }
 
   public setToken(key: string, value: string): string {
-    const cookie = (document.cookie = `${key} = ${value}`);
+    const cookie = (document.cookie = `${key}=${encodeURIComponent(value)}; path=/`);
     return cookie;
   }
 
   public clearToken() {
-    document.cookie = "max-age=0";
+    const cookies = document.cookie.split("; ");
+    for (const cookie of cookies) {
+      const [cookieKey] = cookie.split("=");
+      if (cookieKey) {
+        document.cookie = `${cookieKey}=; path=/; max-age=0`;
+      }
+    }
   }
 }
 

--- a/templates/vite-axios/js/package.json
+++ b/templates/vite-axios/js/package.json
@@ -7,8 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview",
-    "postinstall": "mv gitignore .gitignore || true"
+    "preview": "vite preview"
   },
   "dependencies": {
     "react": "^18.3.1",

--- a/templates/vite-axios/js/src/libs/axios/requestInterceptor.js
+++ b/templates/vite-axios/js/src/libs/axios/requestInterceptor.js
@@ -2,14 +2,17 @@
 import token from "../token/token";
 import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY, REQUEST_TOKEN_KEY } from "../../constants/token.constants";
 
-const requestInterceptor = (config , url) => {
+// CHANGE THIS to your login URL
+const LOGIN_URL = "/login";
+
+const requestInterceptor = (config) => {
   if (typeof window !== "undefined") {
     const accessToken = token.getToken(ACCESS_TOKEN_KEY);
     const refreshToken = token.getToken(REFRESH_TOKEN_KEY);
 
     if (!accessToken || !refreshToken) {
       console.error("Access token or refresh token not found.");
-      window.location.href = url;
+      window.location.href = LOGIN_URL;
     } else {
       config.headers[REQUEST_TOKEN_KEY] = `Bearer ${accessToken}`;
     }

--- a/templates/vite-axios/js/src/libs/axios/responseInterceptor.js
+++ b/templates/vite-axios/js/src/libs/axios/responseInterceptor.js
@@ -30,7 +30,7 @@ const ResponseHandler = async (error) => {
 
       try {
         const { data: newAccessToken } = await axios.post(`${CONFIG.server}/refresh`, {
-          refreshToken: usingAccessToken,
+          refreshToken: usingRefreshToken,
         }); //CHANGE YOUR API URL && BODY VALUE
         customAxios.defaults.headers.common[REQUEST_TOKEN_KEY] = `Bearer ${newAccessToken}`;
 

--- a/templates/vite-axios/js/src/libs/token/token.js
+++ b/templates/vite-axios/js/src/libs/token/token.js
@@ -11,12 +11,18 @@ class Token {
   }
 
   setToken(key, value) {
-    document.cookie = `${key}=${value}`;
+    document.cookie = `${key}=${encodeURIComponent(value)}; path=/`;
     return document.cookie;
   }
 
   clearToken() {
-    document.cookie = "max-age=0";
+    const cookies = document.cookie.split("; ");
+    for (const cookie of cookies) {
+      const [cookieKey] = cookie.split("=");
+      if (cookieKey) {
+        document.cookie = `${cookieKey}=; path=/; max-age=0`;
+      }
+    }
   }
 }
 

--- a/templates/vite-axios/js/vite.config.js
+++ b/templates/vite-axios/js/vite.config.js
@@ -1,30 +1,31 @@
 import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react-swc'
+import react from '@vitejs/plugin-react'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   build: {
     outDir: 'build',
-    sourcemap: false, 
-    minify: 'esbuild', 
+    sourcemap: false,
+    minify: 'esbuild',
     rollupOptions: {
       output: {
         manualChunks(id) {
           if (id.includes('node_modules')) {
-            return 'vendor'; 
+            return 'vendor'
           }
         },
       },
     },
   },
   resolve: {
-    //추가
     alias: [
-      {
-        find: '@src',
-        replacement: path.resolve(__dirname, 'src'),
-      },
+      { find: 'src', replacement: path.resolve(__dirname, 'src') },
+      { find: '@src', replacement: path.resolve(__dirname, 'src') },
     ],
   },
 });

--- a/templates/vite-axios/ts/package.json
+++ b/templates/vite-axios/ts/package.json
@@ -7,14 +7,14 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview",
-    "postinstall": "mv gitignore .gitignore || true"
+    "preview": "vite preview"
   },
   "dependencies": {
     "axios": "^1.7.7",
-    "path": "^0.12.7",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "styled-components": "^6.1.13",
+    "styled-reset": "^4.5.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/templates/vite-axios/ts/src/App.tsx
+++ b/templates/vite-axios/ts/src/App.tsx
@@ -1,11 +1,10 @@
-import logo from '../public/logo.svg';
 import './App.css';
 
 function App() {
   return (
     <div className="App">
       <header className="App-background">
-        <img src={logo} className="App-logo" alt="logo" />
+        <img src="/logo.svg" className="App-logo" alt="logo" />
         <p>B1ND AUTH-TEMPLATE</p>
         <a
           className="App-link"

--- a/templates/vite-axios/ts/src/libs/axios/customAxios.ts
+++ b/templates/vite-axios/ts/src/libs/axios/customAxios.ts
@@ -13,7 +13,7 @@ const axiosRequestConfig: AxiosRequestConfig = {
 
 const customAxios = axios.create(axiosRequestConfig);
 
-customAxios.interceptors.request.use(requestInterceptor as any, (err) => Promise.reject(err));
+customAxios.interceptors.request.use(requestInterceptor, (err) => Promise.reject(err));
 
 customAxios.interceptors.response.use((res) => res, ResponseHandler);
 

--- a/templates/vite-axios/ts/src/libs/axios/requestInterceptor.ts
+++ b/templates/vite-axios/ts/src/libs/axios/requestInterceptor.ts
@@ -2,14 +2,17 @@ import { InternalAxiosRequestConfig } from "axios";
 import token from "../token/token";
 import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY, REQUEST_TOKEN_KEY } from "../../constants/token.constants";
 
-const requestInterceptor = (config: InternalAxiosRequestConfig, url: string): InternalAxiosRequestConfig => {
+// CHANGE THIS to your login URL
+const LOGIN_URL = "/login";
+
+const requestInterceptor = (config: InternalAxiosRequestConfig): InternalAxiosRequestConfig => {
   if (typeof window !== "undefined") {
     const accessToken = token.getToken(ACCESS_TOKEN_KEY);
     const refreshToken = token.getToken(REFRESH_TOKEN_KEY);
 
     if (!accessToken || !refreshToken) {
       console.error("Access token or refresh token not found.");
-      window.location.href = url;
+      window.location.href = LOGIN_URL;
     } else {
       config.headers[REQUEST_TOKEN_KEY] = `Bearer ${accessToken}`;
     }

--- a/templates/vite-axios/ts/src/libs/axios/responseInterceptor.ts
+++ b/templates/vite-axios/ts/src/libs/axios/responseInterceptor.ts
@@ -30,7 +30,7 @@ const ResponseHandler = async (error: AxiosError) => {
 
       try {
         const { data: newAccessToken } = await axios.post(`${CONFIG.server}/refresh`, {
-          refreshToken: usingAccessToken,
+          refreshToken: usingRefreshToken,
         }); //CHANGE YOUR API URL && BODY VALUE
         customAxios.defaults.headers.common[REQUEST_TOKEN_KEY] = `Bearer ${newAccessToken}`;
 

--- a/templates/vite-axios/ts/src/libs/token/token.ts
+++ b/templates/vite-axios/ts/src/libs/token/token.ts
@@ -14,12 +14,18 @@ class Token {
   }
 
   public setToken(key: string, value: string): string {
-    const cookie = (document.cookie = `${key} = ${value}`);
+    const cookie = (document.cookie = `${key}=${encodeURIComponent(value)}; path=/`);
     return cookie;
   }
 
   public clearToken() {
-    document.cookie = "max-age=0";
+    const cookies = document.cookie.split("; ");
+    for (const cookie of cookies) {
+      const [cookieKey] = cookie.split("=");
+      if (cookieKey) {
+        document.cookie = `${cookieKey}=; path=/; max-age=0`;
+      }
+    }
   }
 }
 

--- a/templates/vite-axios/ts/vite.config.ts
+++ b/templates/vite-axios/ts/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react-swc';
+import react from '@vitejs/plugin-react';
 import path from 'path';
 
 // https://vitejs.dev/config/
@@ -7,25 +7,22 @@ export default defineConfig({
   plugins: [react()],
   build: {
     outDir: 'build',
-    sourcemap: false, 
-    minify: 'esbuild', 
+    sourcemap: false,
+    minify: 'esbuild',
     rollupOptions: {
       output: {
         manualChunks(id: string | string[]) {
           if (id.includes('node_modules')) {
-            return 'vendor'; 
+            return 'vendor';
           }
         },
       },
     },
   },
   resolve: {
-    //추가
     alias: [
-      {
-        find: '@src',
-        replacement: path.resolve(__dirname, 'src'),
-      },
+      { find: 'src', replacement: path.resolve(__dirname, 'src') },
+      { find: '@src', replacement: path.resolve(__dirname, 'src') },
     ],
   },
 });

--- a/templates/vite/js/package.json
+++ b/templates/vite/js/package.json
@@ -7,8 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview",
-    "postinstall": "mv gitignore .gitignore || true"
+    "preview": "vite preview"
   },
   "dependencies": {
     "react": "^18.3.1",

--- a/templates/vite/js/vite.config.js
+++ b/templates/vite/js/vite.config.js
@@ -1,30 +1,31 @@
 import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react-swc'
+import react from '@vitejs/plugin-react'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   build: {
     outDir: 'build',
-    sourcemap: false, 
-    minify: 'esbuild', 
+    sourcemap: false,
+    minify: 'esbuild',
     rollupOptions: {
       output: {
         manualChunks(id) {
           if (id.includes('node_modules')) {
-            return 'vendor'; 
+            return 'vendor'
           }
         },
       },
     },
   },
   resolve: {
-    //추가
     alias: [
-      {
-        find: '@src',
-        replacement: path.resolve(__dirname, 'src'),
-      },
+      { find: 'src', replacement: path.resolve(__dirname, 'src') },
+      { find: '@src', replacement: path.resolve(__dirname, 'src') },
     ],
   },
 });

--- a/templates/vite/ts/package.json
+++ b/templates/vite/ts/package.json
@@ -7,8 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview",
-    "postinstall": "mv gitignore .gitignore || true"
+    "preview": "vite preview"
   },
   "dependencies": {
     "path": "^0.12.7",

--- a/templates/vite/ts/vite.config.ts
+++ b/templates/vite/ts/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react-swc';
+import react from '@vitejs/plugin-react';
 import path from 'path';
 
 // https://vitejs.dev/config/
@@ -7,25 +7,22 @@ export default defineConfig({
   plugins: [react()],
   build: {
     outDir: 'build',
-    sourcemap: false, 
-    minify: 'esbuild', 
+    sourcemap: false,
+    minify: 'esbuild',
     rollupOptions: {
       output: {
         manualChunks(id: string | string[]) {
           if (id.includes('node_modules')) {
-            return 'vendor'; 
+            return 'vendor';
           }
         },
       },
     },
   },
   resolve: {
-    //추가
     alias: [
-      {
-        find: '@src',
-        replacement: path.resolve(__dirname, 'src'),
-      },
+      { find: 'src', replacement: path.resolve(__dirname, 'src') },
+      { find: '@src', replacement: path.resolve(__dirname, 'src') },
     ],
   },
 });

--- a/templates/webpack/js/package.json
+++ b/templates/webpack/js/package.json
@@ -17,8 +17,7 @@
     "dev": "webpack serve --config webpack.development.js --progress",
     "build": "webpack --config webpack.production.js --progress",
     "test": "react-scripts test",
-    "eject": "react-scripts eject",
-    "postinstall": "mv gitignore .gitignore || true"
+    "eject": "react-scripts eject"
   },
   "devDependencies": {
     "crypto-browserify": "^3.12.0",

--- a/templates/webpack/ts/package.json
+++ b/templates/webpack/ts/package.json
@@ -18,8 +18,7 @@
     "dev": "webpack serve --config webpack.development.js --progress",
     "build": "webpack --config webpack.production.js --progress",
     "test": "react-scripts test",
-    "eject": "react-scripts eject",
-    "postinstall": "mv gitignore .gitignore || true"
+    "eject": "react-scripts eject"
   },
   "devDependencies": {
     "crypto-browserify": "^3.12.0",


### PR DESCRIPTION
## What?

- CLI 플래그(`--bundler`, `--language`, `--package-manager`, `--axios`, `--skip-install`)가 무시되던 문제 수정
- `--version`이 항상 `1.0.0`을 출력하던 문제 수정
- 모든 템플릿의 죽은 `postinstall: mv gitignore .gitignore` 제거
- Vite 템플릿이 잘못된 플러그인(`@vitejs/plugin-react-swc`)을 import해서 빌드 실패하던 문제 수정
- Vite 템플릿의 누락된 `src` alias, `path` import, `styled-components` 의존성 추가
- axios `responseInterceptor`의 refresh body에 access 토큰을 보내던 버그 수정
- axios `requestInterceptor`의 잘못된 `url` 파라미터로 `undefined` 페이지로 이동하던 버그 수정
- `token.setToken`의 띄어쓰기로 쿠키가 망가지던 버그 수정
- `token.clearToken`이 실제로 쿠키를 지우지 않던 버그 수정

## Why?

- 비대화형 환경에서 CLI 사용 불가
- 생성된 Vite 프로젝트가 즉시 빌드 실패
- axios 토큰 갱신/저장 로직이 실제로 동작하지 않음

## How?

커밋 4개로 그룹화:
1. `feat :: CLI 플래그 비대화형 실행 지원 및 버전 표시 수정`
2. `fix :: 모든 템플릿의 죽은 postinstall 스크립트 제거`
3. `fix :: Vite 템플릿 설정 및 의존성 정리`
4. `fix :: axios 인터셉터 및 쿠키 토큰 처리 버그 수정`